### PR TITLE
Create entrypoint for pyladies CLI, fixes #15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,10 @@ setup(name='pyladies',
       long_description=long_description,
       install_requires=['Sphinx', 'sphinx-rtd-theme'],
       packages=['pyladies'],
+      entry_points = {
+          'console_scripts': [
+            'pyladies = pyladies.main:main'
+          ]
+      },
       include_package_data=True
       )


### PR DESCRIPTION
Just wanted to check out the handbook (I realize it just opens http://kit.pyladies.com/en/latest/ now), followed the instructions

```
$ pip install pyladies
$ pyladies handbook
```

then noticed it was just missing an entrypoint on installation. This fixes that!
