### PR TITLE
Ensure pyladies handbook command works for Python 3.4

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Julia Evans <julia@jvns.ca>
 Lynn Root <erin.lynn.root@gmail.com>
 Lynn Root <lynn@spotify.com>
 audreyr <audreyr@gmail.com>
+Cea Stapleton <cea.stapleton@gmail.com>

--- a/pyladies/main.py
+++ b/pyladies/main.py
@@ -25,13 +25,18 @@ def main(argv=sys.argv[1:]):
     dist = pkg_resources.get_distribution('pyladies')
 
     parser = argparse.ArgumentParser(
-        description="Everything you need to start your own PyLadies location",
-        version=dist.version
+        description="Everything you need to start your own PyLadies location"
     )
     parser.add_argument(
         'handbook',
         help='read the handbook',
     )
+    parser.add_argument('--version',
+        action='version', default=argparse.SUPPRESS,
+        version=dist.version,
+        help="show program's version number and exit"
+    )
+
     parsed_args = parser.parse_args(argv)
 
     if parsed_args.handbook:


### PR DESCRIPTION
Encountered the following trying to run pyladies handbook: 
https://gist.github.com/ceaess/f481adb1433b00d9be91

Turns out that 'self.version' is broken intentionally in Python 3.4 ( http://bugs.python.org/issue13248 ) & ( http://hg.python.org/cpython/rev/5393382c1b1d#l1.15 ), this commit fixes it for you.
