### PR TITLE
Remove extra about link

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -3,8 +3,6 @@
 Overview
 ========
 
-.. _about:
-
 About
 =====
 


### PR DESCRIPTION
I've removed the link to the about section in the overview text - this removes the extra about link!
