### PR TITLE
Added references to the Slack group on conctact pages and removed Google+

### DIFF
--- a/docs/global/contact.rst
+++ b/docs/global/contact.rst
@@ -10,12 +10,19 @@ Points of Contact
 
 .. _Our general email: info@pyladies.com
 
-If you have more casual questions, IRC is one of the best places to start.  You can usually find several of the main PyLadies points of contact in #pyladies.
+If you have more casual questions, Slack or IRC is one of the best places to start.  You can usually find several of the main PyLadies points of contact in #pyladies.
 
 Online Community
 ----------------
 
-Whether or not you’re part of a local group, the PyLadies community online welcomes you the IRC.
+Whether or not you’re part of a local group, the PyLadies community online welcomes you on Slack as well as IRC.
+
+Slack
+~~~~~
+
+We have a Pyladies Slack group that you can join by visiting the `Slack sign-up link`_.    
+
+You can find channels for your local chapter in the Slack group, as well as create new channels for your location, interests, etc. 
 
 IRC
 ~~~
@@ -30,12 +37,12 @@ Anyone can plan and host virtual meetups in IRC #pyladies. You should host one! 
 
 You can also create #pyladies-whatever IRC channels for your country, language, interest group, etc. Ask sandpy for help registering your channel under the #pyladies namespace.
 
+
 Social Media
 ~~~~~~~~~~~~
 
-We have a `Facebook Community`_ page and `Google+ Community`_ page as well were all PyLadies and PyLadies-allies are welcome to post and participate in discussions.  We also tweet from the official `PyLadies Twitter`_ handle.
+We have a `Facebook Community`_ page where all PyLadies and PyLadies-allies are welcome to post and participate in discussions. We also tweet from the official `PyLadies Twitter`_ handle.    
 
-
+.. _Slack sign-up link: https://slackin.pyladies.com
 .. _Facebook Community: https://www.facebook.com/pyladies
-.. _Google+ Community: https://plus.google.com/communities/108807002736066163985
 .. _PyLadies Twitter: https://twitter.com/pyladies

--- a/docs/prospective/faqs.rst
+++ b/docs/prospective/faqs.rst
@@ -52,12 +52,13 @@ The PSF will `most likely reimburse <psf-reimburse>`_ your Meetup.com organizer 
 What if my question isn’t answered here?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Ask in IRC #pyladies on `freenode <irc>`_ if you wish. But feel free to organize your PyLadies group however you wish, and make it completely your own. We’re here to help you, not to limit you or control your plans.
+Ask on `Slack`_ or in IRC #pyladies on `freenode <irc>`_ if you wish. But feel free to organize your PyLadies group however you wish, and make it completely your own. We’re here to help you, not to limit you or control your plans.
 
 
 .. _PyLadies leadership: mailto:info@pyladies.com
 .. _spreadshirt site: https://pyladies.spreadshirt.com
 .. _PyLadies assets repo: https://github.com/pyladies/pyladies-kit
 .. _email: mailto:info@pyladies.com
+.. _slack: https://slackin.pyladies.com/
 .. _irc: http://irc.freenode.net
 .. _psf-reimburse: http://pyfound.blogspot.com/2012/03/user-groups-psf-can-help-cover-your.html

--- a/docs/prospective/index.rst
+++ b/docs/prospective/index.rst
@@ -77,8 +77,8 @@ Once you have received a confirmation that the the initial PyLadies request form
 
     1. Twitter
     2. Facebook
-    3. Google+
-    4. GitHub
+    3. GitHub
+    4. Slack
     5. IRC/Freenode
 
 
@@ -109,7 +109,7 @@ Once you have received a confirmation that the the initial PyLadies request form
     1. `PyLadies Global Organizers list`_ - all global organizational communication and coordination is done via this list.  You'll be introduced to the mailing list.
     2. `PyLadies Global Members list`_ - a global list for PyLadies (and PyGent allies) members. Feel free to introduce yourself and the new location.
 
-7. If you're familiar with IRC, come hang out in the ``#pyladies`` channel on Freenode.
+7. Join the `Pyladies Slack group`_. If you're familiar with IRC, come hang out in the ``#pyladies`` channel on Freenode.
 
 8. Plan your first event!  Check out :doc:`../organizer/neworganizer` for New Organizer information. Start promoting your new group via various local channels, including meetup.com, local PUGs, related groups, and universities, as well as the global PyLadies Members list!
 
@@ -123,7 +123,7 @@ FAQs
 Questions & Contact
 -------------------
 
-If you have any questions or concerns about the process, `drop us an email <ping us>`_ or ping ``roguelynn`` or ``estherbester`` in the ``#pyladies`` channel on Freenode!
+If you have any questions or concerns about the process, `drop us an email <ping us>`_ or ping ``roguelynn`` or ``estherbester`` on Slack or in the ``#pyladies`` channel on Freenode!
 
 .. _ping us: mailto:info@pyladies.com
 .. _grant process: https://www.python.org/psf/grants
@@ -132,3 +132,4 @@ If you have any questions or concerns about the process, `drop us an email <ping
 .. _PyLadies resource form: https://docs.google.com/forms/d/1f1jCD_XOf-06ifZkuSvAdCG9_Me0FnDWNxLQZY-JktU/viewform
 .. _PyLadies Global Organizers list: https://groups.google.com/d/forum/pyladies-group-organizers
 .. _PyLadies Global Members list: https://groups.google.com/d/forum/pyladies
+.. _Pyladies Slack group: https://slackin.pyladies.com/


### PR DESCRIPTION
I added links to the Slack group on the Contact and Prospective Organizers pages re: https://github.com/pyladies/pyladies-kit/issues/45