### PR TITLE
Update CoC to use the PSF's

### DIFF
--- a/docs/policies/coc.md
+++ b/docs/policies/coc.md
@@ -1,9 +1,43 @@
 # Code of Conduct
 
-As a fiscal sponsoree of the Python Software Foundation, we adhere to their [Code of Conduct][PSF COC].
-It is also copied below. Refer to the [PSF's policies] for [a best practices guide for a Code of Conduct
-for Events][events], the [PSF's Code of Conduct Working Group Enforcement Procedures][procedures], and
-the [PSF's Community Member Procedure for Reporting Code of Conduct Incidents][incidents].
+As a fiscal sponsoree of the Python Software Foundation, we adhere to their Code of Conduct.
+It is copied below, but refer to the [PSF's CoC] for the most recent version. In addition, 
+refer to the [PSF's policies] for:
+
+* [a best practices guide for a Code of Conduct for Events][events], 
+* the [PSF's Code of Conduct Working Group Enforcement Procedures][procedures], and 
+* the [PSF's Community Member Procedure for Reporting Code of Conduct Incidents][incidents].
+
+```{attention} Scope Adaptations for PyLadies
+In addition to the [Scope](#scope) detailed below, this is also applicable to PyLadies related events
+and online spaces. This includes:
+
+* local PyLadies chapter events and meetups
+* PyLadies global events at Python conferences
+* PyLadies-focused conferences
+* PyLadies local and global mailing lists
+* PyLadies local and global Slack organizations
+* code repositories, issues, and pull requests within any PyLadies-controlled GitHub organization
+* comments & responses made on official PyLadies organization & PyLadies conference social media accounts, hashtags, and hosted media
+* any other online space administered by PyLadies
+
+In addition to what the [scope](#scope) below includes for whom the CoC applies, it also applies to:
+
+* PyLadies Global Council members
+* PyLadies chapter organizers and leaders
+* PyLadies maintainers, reviewers, and contributors
+* PyLadies online administrators
+* all community members
+```
+
+```{attention} Additional Contacts
+In addition to the [PSF contact information](#contact-information) available for reporting violations
+or raising concerns, you can also reach out to [coc@pyladies.com](mailto:coc@pyladies.com) which is
+monitored by Tania Allard and Bethany Garcia. There is also the `@admin` group within the global 
+[PyLadies Slack organization](pyladies.slack.com) (join via [slackin.pyladies.com]
+(https://slackin.pyladies.com) that you can privately message (click into the `@admin` group to see
+the individuals who are a part of the group), as well as the `#pyladies-support` channel.
+```
 
 ## Python Software Foundation Code of Conduct
 
@@ -61,7 +95,7 @@ No weapons are allowed at Python Software Foundation events. Weapons include but
 
 #### Consequences
 
-If a participant engages in behavior that violates this code of conduct, the Python community Code of Conduct team may take any action they deem appropriate, including warning the offender or expulsion from the community and community events with no refund of event tickets. The full list of consequences for inappropriate behavior is listed in the [Enforcement Procedures](Enforcement-Procedures.md).
+If a participant engages in behavior that violates this code of conduct, the Python community Code of Conduct team may take any action they deem appropriate, including warning the offender or expulsion from the community and community events with no refund of event tickets. The full list of consequences for inappropriate behavior is listed in the [Enforcement Procedures][procedures].
 
 Thank you for helping make this a welcoming, friendly community for everyone.
 
@@ -136,15 +170,15 @@ Each online space listed above is encouraged to provide the following informatio
 
 The Python Software Foundation Code of Conduct work group will receive and evaluate incident reports from the online communities listed above. The Python Software Foundation Code of Conduct work group will work with online community administrators/moderators to suggest actions to take in response to a report. In cases where the administrators/moderators disagree on the suggested resolution for a report, the Python Software Foundation Code of Conduct work group may choose to notify the Python Software Foundation board.
 
-##### Contact Information
+### Contact Information
 
 If you believe that someone is violating the code of conduct, or have any other concerns, please contact a member of the Python Software Foundation Code of Conduct work group immediately. They can be reached by emailing <conduct-wg@python.org>
 
 ### Procedure for Handling Incidents
 
-[Python Software Foundation Community Member Procedure For Reporting Code of Conduct Incidents](Procedures-for-Reporting-Incidents.md)
+[Python Software Foundation Community Member Procedure For Reporting Code of Conduct Incidents][incidents]
 
-[Python Software Foundation Code of Conduct Working Group Enforcement Procedures](Enforcement-Procedures.md)
+[Python Software Foundation Code of Conduct Working Group Enforcement Procedures][procedures]
 
 ### License
 
@@ -168,7 +202,7 @@ Language was incorporated from the following Codes of Conduct:
 * [PyCon 2018 Code of Conduct](https://us.pycon.org/2018/about/code-of-conduct/), licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
 * [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html)
 
-[PSF COC]: https://policies.python.org/python.org/code-of-conduct/
+[PSF's CoC]: https://policies.python.org/python.org/code-of-conduct/
 [PSF's policies]: https://policies.python.org/
 [events]: https://policies.python.org/python.org/code-of-conduct/Best-Practices/
 [procedures]: https://policies.python.org/python.org/code-of-conduct/Enforcement-Procedures/

--- a/docs/policies/coc.md
+++ b/docs/policies/coc.md
@@ -1,32 +1,175 @@
 # Code of Conduct
 
-## Policy
+As a fiscal sponsoree of the Python Software Foundation, we adhere to their [Code of Conduct][PSF COC].
+It is also copied below. Refer to the [PSF's policies] for [a best practices guide for a Code of Conduct
+for Events][events], the [PSF's Code of Conduct Working Group Enforcement Procedures][procedures], and
+the [PSF's Community Member Procedure for Reporting Code of Conduct Incidents][incidents].
 
-All PyLadies events (Meetups, conference lunches, etc), online spaces (Slack, Facebook, etc) are beholden to the PyLadies {ref}`coc`.
+## Python Software Foundation Code of Conduct
 
-Every PyLadies location is **required** to make {ref}`coc` public in some way. For instance, PyLadies SF has a dedicated [page] on their Meetup space.
-The {ref}`PyLadies Slack org<slack>` `#general` channel has a link to the [main website's] Code of Conduct in the topic of the channel.
+The Python community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community, this Code of Conduct will help steer your interactions and keep Python a positive, successful, and growing community.
 
-If you can not find the following {ref}`coc`` posted somewhere (e.g. wherever they post events), please reach out to your chapter's organizers.
 
-Please see {ref}`coc-report` for how to report a CoC violation.
+### Our Community
 
-Please see {ref}`coc-respond` for how to appropriately respond with a CoC violation.
+Members of the Python community are **open, considerate, and respectful**. Behaviours that reinforce these values contribute to a positive environment, and include:
 
-(coc)=
-## Code of Conduct
+ * **Being open.** Members of the community are open to collaboration, whether it's on PEPs, patches, problems, or otherwise.
+ * **Focusing on what is best for the community.** We're respectful of the processes set forth in the community, and we work within them.
+ * **Acknowledging time and effort.** We're respectful of the volunteer efforts that permeate the Python community. We're thoughtful when addressing the efforts of others, keeping in mind that often times the labor was completed simply for the good of the community.
+ * **Being respectful of differing viewpoints and experiences.** We're receptive to constructive comments and criticism, as the experiences and skill sets of other members contribute to the whole of our efforts.
+ * **Showing empathy towards other community members.** We're attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
+ * **Being considerate.** Members of the community are considerate of their peers -- other Python users.
+ * **Being respectful.** We're respectful of others, their positions, their skills, their commitments, and their efforts.
+ * **Gracefully accepting constructive criticism.** When we disagree, we are courteous in raising our issues.
+ * **Using welcoming and inclusive language.** We're accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference.
 
-PyLadies is dedicated to providing a respectful, harassment-free community for everyone. We do not tolerate harassment or bullying of any community member in any form. This does not only extend to members to local PyLadies communities, but to anyone who chooses to become involved in the larger PyLadies community of users, developers and integrators through events or interactions.
 
-Harassment includes offensive verbal/electronic comments related to personal characteristics or choices, sexual images or comments in public or online spaces, deliberate intimidation, bullying, stalking, following, harassing photography or recording, sustained disruption of talks, IRC/Slack chats, electronic meetings, physical meetings or other events, inappropriate physical contact, or unwelcome sexual attention. Participants asked to stop any harassing or bullying behavior are expected to comply immediately.
 
-If a participant engages in harassing behavior, representatives of the community may take reasonable action they deem appropriate, including warning the offender, expulsion from any PyLadies event, or expulsion from mailing lists, IRC/Slack chats, discussion boards and other electronic communications channels to resolve the issue. This may include expulsion from PyLadies Meetup group membership.
+### Our Standards
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please act to intercede or ask for help from any member of the PyLadies community, IRC/Slack chat admins, website admins, or organizers/representatives of any physical events put on under the auspices of PyLadies.
+Every member of our community has the right to have their identity respected. The Python community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
 
-This Code of Conduct has been adapted from the [Plone Foundation] and is licensed under a Creative Commons Attribution-Share Alike 3.0 Unported [license].
 
-[page]: http://www.meetup.com/PyLadiesSF/pages/Code_Of_Conduct/
-[main website's]: http://www.pyladies.com/CodeOfConduct/
-[license]: http://creativecommons.org/licenses/by-sa/3.0/
-[plone foundation]: http://plone.org/foundation/materials/foundation-resolutions/code-of-conduct
+#### Inappropriate Behavior
+
+Examples of unacceptable behavior by participants include:
+
+ * Harassment of any participants in any form
+ * Deliberate intimidation, stalking, or following
+ * Logging or taking screenshots of online activity for harassment purposes
+ * Publishing others' private information, such as a physical or electronic address, without explicit permission
+ * Violent threats or language directed against another person
+ * Incitement of violence or harassment towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+ * Creating additional online accounts in order to harass another person or circumvent a ban
+ * Sexual language and imagery in online communities or in any conference venue, including talks
+ * Insults, put downs, or jokes that are based upon stereotypes, that are exclusionary, or that hold others up for ridicule
+ * Excessive swearing
+ * Unwelcome sexual attention or advances
+ * Unwelcome physical contact, including simulated physical contact (eg, textual descriptions like "hug" or "backrub") without consent or after a request to stop
+ * Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+ * Sustained disruption of online community discussions, in-person presentations, or other in-person events
+ * Continued one-on-one communication after requests to cease
+ * Other conduct that is inappropriate for a professional audience including people of many different backgrounds
+
+Community members asked to stop any inappropriate behavior are expected to comply immediately.
+
+
+#### Weapons Policy
+
+No weapons are allowed at Python Software Foundation events. Weapons include but are not limited to explosives (including fireworks), guns, and large knives such as those used for hunting or display, as well as any other item used for the purpose of causing injury or harm to others. Anyone seen in possession of one of these items will be asked to leave immediately, and will only be allowed to return without the weapon.
+
+#### Consequences
+
+If a participant engages in behavior that violates this code of conduct, the Python community Code of Conduct team may take any action they deem appropriate, including warning the offender or expulsion from the community and community events with no refund of event tickets. The full list of consequences for inappropriate behavior is listed in the [Enforcement Procedures](Enforcement-Procedures.md).
+
+Thank you for helping make this a welcoming, friendly community for everyone.
+
+### Scope
+
+#### PSF Events
+
+This Code of Conduct applies to the following people at events hosted by the Python Software Foundation, and [events hosted by projects under the PSF's fiscal sponsorship](https://www.python.org/psf/fiscal-sponsorees/):
+
+ * staff
+ * Python Software Foundation board members
+ * speakers
+ * panelists
+ * tutorial or workshop leaders
+ * poster presenters
+ * people invited to meetings or summits
+ * exhibitors
+ * organizers
+ * volunteers
+ * all attendees
+
+The Code of Conduct applies in official venue event spaces, including:
+
+  * exhibit hall or vendor tabling area
+  * panel and presentation rooms
+  * hackathon or sprint rooms
+  * tutorial or workshop rooms
+  * poster session rooms
+  * summit or meeting rooms
+  * staff areas
+  * con suite
+  * meal areas
+  * party suites
+  * walkways, hallways, elevators, and stairs that connect any of the above spaces
+
+The Code of Conduct applies to interactions with official event accounts on social media spaces and phone applications, including:
+
+  * comments made on official conference phone apps
+  * comments made on event video hosting services
+  * comments made on the official event hashtag or panel hashtags
+
+Event organizers will enforce this code throughout the event. Each event is required to provide a Code of Conduct committee that receives, evaluates, and acts on incident reports. Each event is required to provide contact information for the committee to attendees. The event Code of Conduct committee may (but is not required to) ask for advice from the Python Software Foundation Code of Conduct work group. The Python Software Foundation Code of Conduct work group can be reached by emailing <conduct-wg@python.org>.
+
+#### PSF Online Spaces
+
+This Code of Conduct applies to the following online spaces:
+
+ * The [python-ideas](https://mail.python.org/mailman/listinfo/python-ideas), [core-mentorship](https://mail.python.org/mm3/mailman3/lists/core-mentorship.python.org/), [python-dev](https://mail.python.org/mailman/listinfo/python-dev), [docs](https://mail.python.org/mailman/listinfo/docs) mailing lists
+ * All other [mailing lists hosted on python.org](https://mail.python.org/mailman/listinfo)
+ * Python Software Foundation Zulip chat server
+ * Python Software Foundation hosted Discourse server [discuss.python.org](https://discuss.python.org/)
+ * Code repositories, issue trackers, and pull requests made against any Python Software Foundation controlled GitHub organization
+ * The python.org mercurial server [hg.python.org](https://hg.python.org/)
+ * Any other online space administered by the Python Software Foundation
+
+This Code of Conduct applies to the following people in official Python Software Foundation online spaces:
+
+ * PSF Members, including Fellows
+ * admins of the online space
+ * maintainers
+ * reviewers
+ * contributors
+ * all community members
+
+Each online space listed above is required to provide the following information to the Python Software Foundation Code of Conduct work group:
+
+ * contact information for any administrators/moderators
+
+Each online space listed above is encouraged to provide the following information to community members:
+
+ * a welcome message with a link to this Code of Conduct and the contact information for making an incident report <conduct-wg@python.org>
+
+The Python Software Foundation Code of Conduct work group will receive and evaluate incident reports from the online communities listed above. The Python Software Foundation Code of Conduct work group will work with online community administrators/moderators to suggest actions to take in response to a report. In cases where the administrators/moderators disagree on the suggested resolution for a report, the Python Software Foundation Code of Conduct work group may choose to notify the Python Software Foundation board.
+
+##### Contact Information
+
+If you believe that someone is violating the code of conduct, or have any other concerns, please contact a member of the Python Software Foundation Code of Conduct work group immediately. They can be reached by emailing <conduct-wg@python.org>
+
+### Procedure for Handling Incidents
+
+[Python Software Foundation Community Member Procedure For Reporting Code of Conduct Incidents](Procedures-for-Reporting-Incidents.md)
+
+[Python Software Foundation Code of Conduct Working Group Enforcement Procedures](Enforcement-Procedures.md)
+
+### License
+
+This Code of Conduct is licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
+
+[![Creative Commons License](https://licensebuttons.net/l/by-sa/3.0/88x31.png)](http://creativecommons.org/licenses/by-sa/3.0/)
+
+### Attributions
+
+This Code of Conduct was forked from the example policy from the [Geek Feminism wiki, created by the Ada Initiative and other volunteers](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), which is under a [Creative Commons Zero license](https://creativecommons.org/publicdomain/zero/1.0/).
+
+Additional new language and modifications were created by Sage Sharp of [Otter Tech](https://otter.technology/code-of-conduct-training/).
+
+Language was incorporated from the following Codes of Conduct:
+
+* [Affect Conf Code of Conduct](https://affectconf.com/coc/), licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/).
+* [Citizen Code of Conduct](http://citizencodeofconduct.org/), licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/).
+* [Contributor Covenant version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct), licensed [Creative Commons Attribution 4.0 License](https://github.com/ContributorCovenant/contributor_covenant/blob/master/LICENSE.md).
+* [Django Project Code of Conduct](https://www.djangoproject.com/conduct/), licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
+* [LGBTQ in Tech Slack Code of Conduct](https://lgbtq.technology/coc.html), licensed under a [Creative Commons Zero License](https://creativecommons.org/publicdomain/zero/1.0/).
+* [PyCon 2018 Code of Conduct](https://us.pycon.org/2018/about/code-of-conduct/), licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
+* [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html)
+
+[PSF COC]: https://policies.python.org/python.org/code-of-conduct/
+[PSF's policies]: https://policies.python.org/
+[events]: https://policies.python.org/python.org/code-of-conduct/Best-Practices/
+[procedures]: https://policies.python.org/python.org/code-of-conduct/Enforcement-Procedures/
+[incidents]: https://policies.python.org/python.org/code-of-conduct/Procedures-for-Reporting-Incidents/

--- a/docs/policies/coc.md
+++ b/docs/policies/coc.md
@@ -34,9 +34,9 @@ In addition to what the [scope](#scope) below includes for whom the CoC applies,
 In addition to the [PSF contact information](#contact-information) available for reporting violations
 or raising concerns, you can also reach out to [coc@pyladies.com](mailto:coc@pyladies.com) which is
 monitored by Tania Allard and Bethany Garcia. There is also the `@admin` group within the global 
-[PyLadies Slack organization](pyladies.slack.com) (join via [slackin.pyladies.com]
-(https://slackin.pyladies.com) that you can privately message (click into the `@admin` group to see
-the individuals who are a part of the group), as well as the `#pyladies-support` channel.
+[PyLadies Slack organization](pyladies.slack.com) (join via [slackin.pyladies.com](https://slackin.pyladies.com)) 
+that you can privately message (click into the `@admin` group to see the individuals who are a part 
+of the group), as well as the `#pyladies-support` channel.
 ```
 
 ## Python Software Foundation Code of Conduct


### PR DESCRIPTION
As a fiscal sponsoree of the PSF, we are required to use & adhere to their Code of Conduct - finally updating the kit to reflect that!